### PR TITLE
Add Account Detail, Define Profile, and options to better extend the DEP API client

### DIFF
--- a/godep/account.go
+++ b/godep/account.go
@@ -43,7 +43,7 @@ type Limit struct {
 // See https://developer.apple.com/documentation/devicemanagement/get_account_detail
 func (c *Client) AccountDetail(ctx context.Context, name string) (*AccountResponse, error) {
 	resp := new(AccountResponse)
-	return resp, c.doWithErrHook(ctx, name, http.MethodGet, "/account", nil, resp)
+	return resp, c.doWithAfterHook(ctx, name, http.MethodGet, "/account", nil, resp)
 }
 
 // IsTermsNotSigned returns true if err is a DEP "terms and conditions not

--- a/godep/account.go
+++ b/godep/account.go
@@ -1,0 +1,55 @@
+package godep
+
+import (
+	"context"
+	"net/http"
+)
+
+// AccountResponse corresponds to the Apple DEP API "AccountDetail" structure.
+// See https://developer.apple.com/documentation/devicemanagement/accountdetail
+type AccountResponse struct {
+	AdminID       string `json:"admin_id"`
+	FacilitatorID string `json:"facilitator_id"`
+	OrgAddress    string `json:"org_address"`
+	OrgEmail      string `json:"org_email"`
+	OrgID         string `json:"org_id"`
+	OrgIDHash     string `json:"org_id_hash"`
+	OrgName       string `json:"org_name"`
+	OrgPhone      string `json:"org_phone"`
+	OrgType       string `json:"org_type"`
+	OrgVersion    string `json:"org_version"`
+	ServerName    string `json:"server_name"`
+	ServerUUID    string `json:"server_uuid"`
+	URLs          []URL  `json:"urls"`
+}
+
+// URL corresponds to the Apple DEP API "Url" structure.
+// See https://developer.apple.com/documentation/devicemanagement/url
+type URL struct {
+	HTTPMethod []string `json:"http_method"`
+	Limit      *Limit   `json:"limit"`
+	URI        string   `json:"uri"`
+}
+
+// Limit corresponds to the Apple DEP API "Limit" structure.
+// See https://developer.apple.com/documentation/devicemanagement/limit
+type Limit struct {
+	Default int `json:"default"`
+	Maximum int `json:"maximum"`
+}
+
+// AccountDetail uses the Apple "Get Account Detail" API endpoint to get the
+// account details for the current DEP authentication token.
+// See https://developer.apple.com/documentation/devicemanagement/get_account_detail
+func (c *Client) AccountDetail(ctx context.Context, name string) (*AccountResponse, error) {
+	resp := new(AccountResponse)
+	return resp, c.do(ctx, name, http.MethodGet, "/account", nil, resp)
+}
+
+// IsTermsNotSigned returns true if err is a DEP "terms and conditions not
+// signed" error. Per Apple this indicates the Terms and Conditions must be
+// accepted by the user.
+// See https://developer.apple.com/documentation/devicemanagement/device_assignment/authenticating_with_a_device_enrollment_program_dep_server/interpreting_error_codes
+func IsTermsNotSigned(err error) bool {
+	return httpErrorContains(err, http.StatusForbidden, "T_C_NOT_SIGNED")
+}

--- a/godep/account.go
+++ b/godep/account.go
@@ -43,7 +43,7 @@ type Limit struct {
 // See https://developer.apple.com/documentation/devicemanagement/get_account_detail
 func (c *Client) AccountDetail(ctx context.Context, name string) (*AccountResponse, error) {
 	resp := new(AccountResponse)
-	return resp, c.do(ctx, name, http.MethodGet, "/account", nil, resp)
+	return resp, c.doWithErrHook(ctx, name, http.MethodGet, "/account", nil, resp)
 }
 
 // IsTermsNotSigned returns true if err is a DEP "terms and conditions not

--- a/godep/account.go
+++ b/godep/account.go
@@ -51,5 +51,6 @@ func (c *Client) AccountDetail(ctx context.Context, name string) (*AccountRespon
 // accepted by the user.
 // See https://developer.apple.com/documentation/devicemanagement/device_assignment/authenticating_with_a_device_enrollment_program_dep_server/interpreting_error_codes
 func IsTermsNotSigned(err error) bool {
-	return httpErrorContains(err, http.StatusForbidden, "T_C_NOT_SIGNED")
+	return httpErrorContains(err, http.StatusForbidden, "T_C_NOT_SIGNED") ||
+		authErrorContains(err, http.StatusForbidden, "T_C_NOT_SIGNED")
 }

--- a/godep/client.go
+++ b/godep/client.go
@@ -57,6 +57,16 @@ func httpErrorContains(err error, status int, s string) bool {
 	return false
 }
 
+// authErrorContains is the same as httpErrorContains except that it checks if
+// err is an depclient.AuthError instead of HTTPError.
+func authErrorContains(err error, status int, s string) bool {
+	var authErr *depclient.AuthError
+	if errors.As(err, &authErr) && authErr.StatusCode == status && bytes.Contains(authErr.Body, []byte(s)) {
+		return true
+	}
+	return false
+}
+
 // ClientStorage provides the required data needed to connect to the Apple DEP APIs.
 type ClientStorage interface {
 	depclient.AuthTokensRetriever

--- a/godep/device.go
+++ b/godep/device.go
@@ -75,7 +75,7 @@ func (c *Client) FetchDevices(ctx context.Context, name string, opts ...DeviceRe
 		opt(req)
 	}
 	resp := new(DeviceResponse)
-	return resp, c.do(ctx, name, http.MethodPost, "/server/devices", req, resp)
+	return resp, c.doWithErrHook(ctx, name, http.MethodPost, "/server/devices", req, resp)
 }
 
 // SyncDevices uses the Apple "Sync the List of Devices" API endpoint to get
@@ -91,7 +91,7 @@ func (c *Client) SyncDevices(ctx context.Context, name string, opts ...DeviceReq
 		opt(req)
 	}
 	resp := new(DeviceResponse)
-	return resp, c.do(ctx, name, http.MethodPost, "/devices/sync", req, resp)
+	return resp, c.doWithErrHook(ctx, name, http.MethodPost, "/devices/sync", req, resp)
 }
 
 // IsCursorExhausted returns true if err is a DEP "exhausted cursor" error.

--- a/godep/device.go
+++ b/godep/device.go
@@ -75,7 +75,7 @@ func (c *Client) FetchDevices(ctx context.Context, name string, opts ...DeviceRe
 		opt(req)
 	}
 	resp := new(DeviceResponse)
-	return resp, c.doWithErrHook(ctx, name, http.MethodPost, "/server/devices", req, resp)
+	return resp, c.doWithAfterHook(ctx, name, http.MethodPost, "/server/devices", req, resp)
 }
 
 // SyncDevices uses the Apple "Sync the List of Devices" API endpoint to get
@@ -91,7 +91,7 @@ func (c *Client) SyncDevices(ctx context.Context, name string, opts ...DeviceReq
 		opt(req)
 	}
 	resp := new(DeviceResponse)
-	return resp, c.doWithErrHook(ctx, name, http.MethodPost, "/devices/sync", req, resp)
+	return resp, c.doWithAfterHook(ctx, name, http.MethodPost, "/devices/sync", req, resp)
 }
 
 // IsCursorExhausted returns true if err is a DEP "exhausted cursor" error.

--- a/godep/profile.go
+++ b/godep/profile.go
@@ -5,6 +5,36 @@ import (
 	"net/http"
 )
 
+// Profile corresponds to the Apple DEP API "Profile" structure.
+// See https://developer.apple.com/documentation/devicemanagement/profile
+type Profile struct {
+	ProfileName           string   `json:"profile_name"`
+	URL                   string   `json:"url"`
+	AllowPairing          bool     `json:"allow_pairing,omitempty"`
+	IsSupervised          bool     `json:"is_supervised,omitempty"`
+	IsMultiUser           bool     `json:"is_multi_user,omitempty"`
+	IsMandatory           bool     `json:"is_mandatory,omitempty"`
+	AwaitDeviceConfigured bool     `json:"await_device_configured,omitempty"`
+	IsMDMRemovable        bool     `json:"is_mdm_removable"` // default true
+	SupportPhoneNumber    string   `json:"support_phone_number,omitempty"`
+	AutoAdvanceSetup      bool     `json:"auto_advance_setup,omitempty"`
+	SupportEmailAddress   string   `json:"support_email_address,omitempty"`
+	OrgMagic              string   `json:"org_magic"`
+	AnchorCerts           []string `json:"anchor_certs,omitempty"`
+	SupervisingHostCerts  []string `json:"supervising_host_certs,omitempty"`
+	Department            string   `json:"department,omitempty"`
+	Devices               []string `json:"devices,omitempty"`
+	Language              string   `json:"language,omitempty"`
+	Region                string   `json:"region,omitempty"`
+	ConfigurationWebURL   string   `json:"configuration_web_url,omitempty"`
+
+	// See https://developer.apple.com/documentation/devicemanagement/skipkeys
+	SkipSetupItems []string `json:"skip_setup_items,omitempty"`
+
+	// additional undocumented key only returned when requesting a profile from Apple.
+	ProfileUUID string `json:"profile_uuid,omitempty"`
+}
+
 // ProfileResponse corresponds to the Apple DEP API "AssignProfileResponse" structure.
 // See https://developer.apple.com/documentation/devicemanagement/assignprofileresponse
 type ProfileResponse struct {
@@ -31,4 +61,15 @@ func (c *Client) AssignProfile(ctx context.Context, name, uuid string, serials .
 	// requires this. however modern Apple documentation says this is a POST
 	// now. we still use PUT here for compatibility.
 	return resp, c.do(ctx, name, http.MethodPut, "/profile/devices", req, resp)
+}
+
+// DefineProfile uses the Apple "Define a Profile" command to attempt to create a profile.
+// This service defines a profile with Apple's servers that can then be assigned to specific devices.
+// This command provides information about the MDM server that is assigned to manage one or more devices,
+// information about the host that the managed devices can pair with, and various attributes that control
+// the MDM association behavior of the device.
+// See https://developer.apple.com/documentation/devicemanagement/define_a_profile
+func (c *Client) DefineProfile(ctx context.Context, name string, profile *Profile) (*ProfileResponse, error) {
+	resp := new(ProfileResponse)
+	return resp, c.do(ctx, name, http.MethodPost, "/profile", profile, resp)
 }

--- a/godep/profile.go
+++ b/godep/profile.go
@@ -60,7 +60,7 @@ func (c *Client) AssignProfile(ctx context.Context, name, uuid string, serials .
 	// historically this has been an HTTP PUT and the DEP simulator depsim
 	// requires this. however modern Apple documentation says this is a POST
 	// now. we still use PUT here for compatibility.
-	return resp, c.do(ctx, name, http.MethodPut, "/profile/devices", req, resp)
+	return resp, c.doWithErrHook(ctx, name, http.MethodPut, "/profile/devices", req, resp)
 }
 
 // DefineProfile uses the Apple "Define a Profile" command to attempt to create a profile.
@@ -71,5 +71,5 @@ func (c *Client) AssignProfile(ctx context.Context, name, uuid string, serials .
 // See https://developer.apple.com/documentation/devicemanagement/define_a_profile
 func (c *Client) DefineProfile(ctx context.Context, name string, profile *Profile) (*ProfileResponse, error) {
 	resp := new(ProfileResponse)
-	return resp, c.do(ctx, name, http.MethodPost, "/profile", profile, resp)
+	return resp, c.doWithErrHook(ctx, name, http.MethodPost, "/profile", profile, resp)
 }

--- a/godep/profile.go
+++ b/godep/profile.go
@@ -60,7 +60,7 @@ func (c *Client) AssignProfile(ctx context.Context, name, uuid string, serials .
 	// historically this has been an HTTP PUT and the DEP simulator depsim
 	// requires this. however modern Apple documentation says this is a POST
 	// now. we still use PUT here for compatibility.
-	return resp, c.doWithErrHook(ctx, name, http.MethodPut, "/profile/devices", req, resp)
+	return resp, c.doWithAfterHook(ctx, name, http.MethodPut, "/profile/devices", req, resp)
 }
 
 // DefineProfile uses the Apple "Define a Profile" command to attempt to create a profile.
@@ -71,5 +71,5 @@ func (c *Client) AssignProfile(ctx context.Context, name, uuid string, serials .
 // See https://developer.apple.com/documentation/devicemanagement/define_a_profile
 func (c *Client) DefineProfile(ctx context.Context, name string, profile *Profile) (*ProfileResponse, error) {
 	resp := new(ProfileResponse)
-	return resp, c.doWithErrHook(ctx, name, http.MethodPost, "/profile", profile, resp)
+	return resp, c.doWithAfterHook(ctx, name, http.MethodPost, "/profile", profile, resp)
 }


### PR DESCRIPTION
Those changes are related to https://github.com/fleetdm/fleet/issues/8862 and the companion PR https://github.com/fleetdm/fleet/pull/9091.

It adds `AccountDetail` as a new DEP client method, as well as `DefineProfile` which is a copy of the code that already exists on the upstream repo.

It defines the `IsTermsNotSigned` helper that detects if an error is due to Apple BM terms having changed and requiring signature, and adds options to `godep.NewClient` to better extend and hook into the API client (in our case, useful to intercept the terms changed error on any API request).